### PR TITLE
Fix/switch to stack calculator

### DIFF
--- a/08-structural-design-patterns/01-proxy-composition/index.js
+++ b/08-structural-design-patterns/01-proxy-composition/index.js
@@ -1,42 +1,74 @@
-class Calculator {
-  divide (dividend, divisor) {
+class StackCalculator {
+  constructor () {
+    this.stack = []
+  }
+
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  divide () {
+    const divisor = this.stack.pop()
+    const dividend = this.stack.pop()
     return dividend / divisor
   }
 
-  multiply (multiplier, multiplicand) {
+  multiply () {
+    const multiplicand = this.stack.pop()
+    const multiplier = this.stack.pop()
     return multiplier * multiplicand
   }
 }
 
-class SafeCalculator extends Calculator {
+class SafeCalculator {
   constructor (calculator) {
-    super()
     this.calculator = calculator
   }
 
   // proxied method
-  divide (dividend, divisor) {
+  divide () {
     // additional validation logic
+    const divisor = this.calculator.peekValue()
     if (divisor === 0) {
       throw Error('Division by 0')
     }
     // if valid delegates to the subject
-    return this.calculator.divide(dividend, divisor)
+    return this.calculator.divide()
   }
 
-  // delegated method
+  // delegated methods
+  putValue (...args) {
+    return this.calculator.putValue(...args)
+  }
+
+  peekValue () {
+    return this.calculator.peekValue()
+  }
+
   multiply (...args) {
     return this.calculator.multiply(...args)
   }
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const safeCalculator = new SafeCalculator(calculator)
 
-console.log(safeCalculator instanceof Calculator) // true
-console.log(calculator.multiply(3, 2)) // 6
-console.log(safeCalculator.multiply(3, 2)) // 6
-console.log(calculator.divide(4, 2)) // 2
-console.log(safeCalculator.divide(4, 2)) // 2
-console.log(calculator.divide(2, 0)) // Infinity
-console.log(safeCalculator.divide(2, 0)) // Error('Division by 0')
+calculator.putValue(3)
+calculator.putValue(2)
+console.log(calculator.multiply()) // 3*2 = 6
+
+safeCalculator.putValue(3)
+safeCalculator.putValue(2)
+console.log(safeCalculator.multiply()) // 3*2 = 6
+
+calculator.putValue(4)
+calculator.putValue(0)
+console.log(calculator.divide()) // 4/0 = Infinity
+
+safeCalculator.putValue(4)
+safeCalculator.putValue(0)
+console.log(safeCalculator.divide()) // 4/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/01-proxy-composition/index.js
+++ b/08-structural-design-patterns/01-proxy-composition/index.js
@@ -7,20 +7,32 @@ class StackCalculator {
     this.stack.push(value)
   }
 
+  getValue () {
+    return this.stack.pop()
+  }
+
   peekValue () {
     return this.stack[this.stack.length - 1]
   }
 
+  clear () {
+    this.stack = []
+  }
+
   divide () {
-    const divisor = this.stack.pop()
-    const dividend = this.stack.pop()
-    return dividend / divisor
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
   }
 
   multiply () {
-    const multiplicand = this.stack.pop()
-    const multiplier = this.stack.pop()
-    return multiplier * multiplicand
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
@@ -41,16 +53,24 @@ class SafeCalculator {
   }
 
   // delegated methods
-  putValue (...args) {
-    return this.calculator.putValue(...args)
+  putValue (value) {
+    return this.calculator.putValue(value)
+  }
+
+  getValue () {
+    return this.calculator.getValue()
   }
 
   peekValue () {
     return this.calculator.peekValue()
   }
 
-  multiply (...args) {
-    return this.calculator.multiply(...args)
+  clear () {
+    return this.calculator.clear()
+  }
+
+  multiply () {
+    return this.calculator.multiply()
   }
 }
 
@@ -61,14 +81,13 @@ calculator.putValue(3)
 calculator.putValue(2)
 console.log(calculator.multiply()) // 3*2 = 6
 
-safeCalculator.putValue(3)
 safeCalculator.putValue(2)
-console.log(safeCalculator.multiply()) // 3*2 = 6
+console.log(safeCalculator.multiply()) // 6*2 = 12
 
-calculator.putValue(4)
 calculator.putValue(0)
-console.log(calculator.divide()) // 4/0 = Infinity
+console.log(calculator.divide()) // 12/0 = Infinity
 
+safeCalculator.clear()
 safeCalculator.putValue(4)
 safeCalculator.putValue(0)
 console.log(safeCalculator.divide()) // 4/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/02-proxy-object-literal/index.js
+++ b/08-structural-design-patterns/02-proxy-object-literal/index.js
@@ -1,39 +1,86 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
 function createSafeCalculator (calculator) {
   return {
     // proxied method
-    divide (dividend, divisor) {
+    divide () {
       // additional validation logic
+      const divisor = calculator.peekValue()
       if (divisor === 0) {
         throw Error('Division by 0')
       }
-
-      return calculator.divide(dividend, divisor)
+      // if valid delegates to the subject
+      return calculator.divide()
     },
-
-    // delegated method
-    multiply (multiplier, multiplicand) {
-      return calculator.multiply(multiplier, multiplicand)
+    // delegated methods
+    putValue (value) {
+      return calculator.putValue(value)
+    },
+    getValue () {
+      return calculator.getValue()
+    },
+    peekValue () {
+      return calculator.peekValue()
+    },
+    clear () {
+      return calculator.clear()
+    },
+    multiply () {
+      return calculator.multiply()
     }
   }
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const safeCalculator = createSafeCalculator(calculator)
 
-console.log(safeCalculator instanceof Calculator) // false!
-console.log(calculator.multiply(3, 2)) // 6
-console.log(safeCalculator.multiply(3, 2)) // 6
-console.log(calculator.divide(4, 2)) // 2
-console.log(safeCalculator.divide(4, 2)) // 2
-console.log(calculator.divide(2, 0)) // Infinity
-console.log(safeCalculator.divide(2, 0)) // Error('Division by 0')
+calculator.putValue(3)
+calculator.putValue(2)
+console.log(calculator.multiply()) // 3*2 = 6
+
+safeCalculator.putValue(2)
+console.log(safeCalculator.multiply()) // 6*2 = 12
+
+calculator.putValue(0)
+console.log(calculator.divide()) // 12/0 = Infinity
+
+safeCalculator.clear()
+safeCalculator.putValue(4)
+safeCalculator.putValue(0)
+console.log(safeCalculator.divide()) // 4/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/03-proxy-object-augmentation/index.js
+++ b/08-structural-design-patterns/03-proxy-object-augmentation/index.js
@@ -1,32 +1,70 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
 function patchToSafeCalculator (calculator) {
   const divideOrig = calculator.divide
-  calculator.divide = (dividend, divisor) => {
+  calculator.divide = () => {
+    // additional validation logic
+    const divisor = calculator.peekValue()
     if (divisor === 0) {
       throw Error('Division by 0')
     }
-
-    return divideOrig(dividend, divisor)
+    // if valid delegates to the subject
+    return divideOrig.apply(calculator)
   }
 
   return calculator
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const safeCalculator = patchToSafeCalculator(calculator)
 
-console.log(calculator.multiply(3, 2)) // 6
-console.log(safeCalculator.multiply(3, 2)) // 6
-console.log(calculator.divide(4, 2)) // 2
-console.log(safeCalculator.divide(4, 2)) // 2
-// console.log(calculator.divide(2, 0)) // Error('Division by 0')
-console.log(safeCalculator.divide(2, 0)) // Error('Division by 0')
+calculator.putValue(3)
+calculator.putValue(2)
+console.log(calculator.multiply()) // 3*2 = 6
+
+safeCalculator.putValue(2)
+console.log(safeCalculator.multiply()) // 6*2 = 12
+
+// calculator.putValue(0)
+// console.log(calculator.divide()) // 12/0 -> Error('Division by 0')
+
+safeCalculator.clear()
+safeCalculator.putValue(4)
+safeCalculator.putValue(0)
+console.log(safeCalculator.divide()) // 4/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/04-proxy-es2015/safe-calculator.js
+++ b/08-structural-design-patterns/04-proxy-es2015/safe-calculator.js
@@ -1,10 +1,38 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
@@ -12,12 +40,14 @@ const safeCalculatorHandler = {
   get: (target, property) => {
     if (property === 'divide') {
       // proxied method
-      return function (dividend, divisor) {
+      return function () {
+        // additional validation logic
+        const divisor = target.peekValue()
         if (divisor === 0) {
           throw Error('Division by 0')
         }
-
-        return target.divide(dividend, divisor)
+        // if valid delegates to the subject
+        return target.divide()
       }
     }
 
@@ -26,13 +56,22 @@ const safeCalculatorHandler = {
   }
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const safeCalculator = new Proxy(calculator, safeCalculatorHandler)
 
-console.log(safeCalculator instanceof Calculator) // true!
-console.log(calculator.multiply(3, 2)) // 6
-console.log(safeCalculator.multiply(3, 2)) // 6
-console.log(calculator.divide(4, 2)) // 2
-console.log(safeCalculator.divide(4, 2)) // 2
-console.log(calculator.divide(2, 0)) // Infinity
-console.log(safeCalculator.divide(2, 0)) // Error('Division by 0')
+console.log(safeCalculator instanceof StackCalculator) // true!
+
+calculator.putValue(3)
+calculator.putValue(2)
+console.log(calculator.multiply()) // 3*2 = 6
+
+safeCalculator.putValue(2)
+console.log(safeCalculator.multiply()) // 6*2 = 12
+
+calculator.putValue(0)
+console.log(calculator.divide()) // 12/0 = Infinity
+
+safeCalculator.clear()
+safeCalculator.putValue(4)
+safeCalculator.putValue(0)
+console.log(safeCalculator.divide()) // 4/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/07-decorator-composition/index.js
+++ b/08-structural-design-patterns/07-decorator-composition/index.js
@@ -1,43 +1,95 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
-class EnhancedCalculator extends Calculator {
+class EnhancedCalculator {
   constructor (calculator) {
-    super()
     this.calculator = calculator
   }
 
   // new method
-  add (...addends) {
-    return addends.reduce((a, b) => a + b, 0)
+  add () {
+    const addend2 = this.getValue()
+    const addend1 = this.getValue()
+    const result = addend1 + addend2
+    this.putValue(result)
+    return result
   }
 
   // modified method
-  divide (dividend, divisor) {
+  divide () {
+    // additional validation logic
+    const divisor = this.calculator.peekValue()
     if (divisor === 0) {
       throw Error('Division by 0')
     }
-
-    return this.calculator(dividend, divisor)
+    // if valid delegates to the subject
+    return this.calculator.divide()
   }
 
-  // delegated method
-  multiply (...args) {
-    return this.calculator.multiply(...args)
+  // delegated methods
+  putValue (value) {
+    return this.calculator.putValue(value)
+  }
+
+  getValue () {
+    return this.calculator.getValue()
+  }
+
+  peekValue () {
+    return this.calculator.peekValue()
+  }
+
+  clear () {
+    return this.calculator.clear()
+  }
+
+  multiply () {
+    return this.calculator.multiply()
   }
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const enhancedCalculator = new EnhancedCalculator(calculator)
 
-console.log(enhancedCalculator instanceof Calculator) // true
-console.log(enhancedCalculator.add(4, 3, 2, 1)) // 10
-console.log(enhancedCalculator.multiply(3, 2)) // 6
-// console.log(enhancedCalculator.divide(3, 0)) // Error('Division by 0')
+enhancedCalculator.putValue(4)
+enhancedCalculator.putValue(3)
+console.log(enhancedCalculator.add()) // 4+3 = 7
+enhancedCalculator.putValue(2)
+console.log(enhancedCalculator.multiply()) // 7*2 = 14
+// enhancedCalculator.putValue(0)
+// console.log(enhancedCalculator.divide()) // 14/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/08-decorator-object-augmentation/index.js
+++ b/08-structural-design-patterns/08-decorator-object-augmentation/index.js
@@ -1,37 +1,73 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
 function patchCalculator (calculator) {
   // new method
-  calculator.add = function (...addends) {
-    return addends.reduce((a, b) => a + b, 0)
+  calculator.add = function () {
+    const addend2 = calculator.getValue()
+    const addend1 = calculator.getValue()
+    const result = addend1 + addend2
+    calculator.putValue(result)
+    return result
   }
 
   // modified method
   const divideOrig = calculator.divide
-  calculator.divide = (dividend, divisor) => {
+  calculator.divide = () => {
+    // additional validation logic
+    const divisor = calculator.peekValue()
     if (divisor === 0) {
       throw Error('Division by 0')
     }
-
-    return divideOrig(dividend, divisor)
+    // if valid delegates to the subject
+    return divideOrig.apply(calculator)
   }
 
   return calculator
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const enhancedCalculator = patchCalculator(calculator)
 
-console.log(enhancedCalculator instanceof Calculator) // true
-console.log(enhancedCalculator.multiply(3, 2)) // 6
-console.log(enhancedCalculator.add(4, 3, 2, 1)) // 10
-console.log(calculator.add(4, 3, 2, 1)) // 10!
-// console.log(enhancedCalculator.divide(3, 0)) // Error('Division by 0')
+enhancedCalculator.putValue(4)
+enhancedCalculator.putValue(3)
+console.log(enhancedCalculator.add()) // 4+3 = 7
+enhancedCalculator.putValue(2)
+console.log(enhancedCalculator.multiply()) // 7*2 = 14
+// enhancedCalculator.putValue(0)
+// console.log(enhancedCalculator.divide()) // 14/0 -> Error('Division by 0')

--- a/08-structural-design-patterns/09-decorator-es2015/index.js
+++ b/08-structural-design-patterns/09-decorator-es2015/index.js
@@ -1,10 +1,38 @@
-class Calculator {
-  divide (dividend, divisor) {
-    return dividend / divisor
+class StackCalculator {
+  constructor () {
+    this.stack = []
   }
 
-  multiply (multiplier, multiplicand) {
-    return multiplier * multiplicand
+  putValue (value) {
+    this.stack.push(value)
+  }
+
+  getValue () {
+    return this.stack.pop()
+  }
+
+  peekValue () {
+    return this.stack[this.stack.length - 1]
+  }
+
+  clear () {
+    this.stack = []
+  }
+
+  divide () {
+    const divisor = this.getValue()
+    const dividend = this.getValue()
+    const result = dividend / divisor
+    this.putValue(result)
+    return result
+  }
+
+  multiply () {
+    const multiplicand = this.getValue()
+    const multiplier = this.getValue()
+    const result = multiplier * multiplicand
+    this.putValue(result)
+    return result
   }
 }
 
@@ -12,17 +40,23 @@ const enhancedCalculatorHandler = {
   get (target, property) {
     if (property === 'add') {
       // new method
-      return function add (...addends) {
-        return addends.reduce((a, b) => a + b, 0)
+      return function add () {
+        const addend2 = target.getValue()
+        const addend1 = target.getValue()
+        const result = addend1 + addend2
+        target.putValue(result)
+        return result
       }
     } else if (property === 'divide') {
       // modified method
-      return function (dividend, divisor) {
+      return function () {
+        // additional validation logic
+        const divisor = target.peekValue()
         if (divisor === 0) {
           throw Error('Division by 0')
         }
-
-        return target.divide(dividend, divisor)
+        // if valid delegates to the subject
+        return target.divide()
       }
     }
 
@@ -31,10 +65,14 @@ const enhancedCalculatorHandler = {
   }
 }
 
-const calculator = new Calculator()
+const calculator = new StackCalculator()
 const enhancedCalculator = new Proxy(calculator, enhancedCalculatorHandler)
 
-console.log(enhancedCalculator instanceof Calculator) // true
-console.log(enhancedCalculator.multiply(3, 2)) // uses original method
-console.log(enhancedCalculator.add(4, 3, 2, 1)) // uses new method
-// console.log(enhancedCalculator.divide(3, 0)) // Error('Division by 0')
+console.log(enhancedCalculator instanceof StackCalculator) // true!
+enhancedCalculator.putValue(4)
+enhancedCalculator.putValue(3)
+console.log(enhancedCalculator.add()) // 4+3 = 7
+enhancedCalculator.putValue(2)
+console.log(enhancedCalculator.multiply()) // 7*2 = 14
+// enhancedCalculator.putValue(0)
+// console.log(enhancedCalculator.divide()) // 14/0 -> Error('Division by 0')


### PR DESCRIPTION
Uses a stateful class to re-implement the basic examples for Proxy and Decorator. This change should make the 2 patterns more clear, especially for those who might wonder what's the difference between these 2 patterns and simply extending a class to change behaviours.