### PR TITLE
async keyword redundant

### DIFF
--- a/05-asynchronous-control-flow-patterns-with-promises-and-async-await/11-asyncawait-web-spider-v4/TaskQueuePC.js
+++ b/05-asynchronous-control-flow-patterns-with-promises-and-async-await/11-asyncawait-web-spider-v4/TaskQueuePC.js
@@ -20,7 +20,7 @@ export class TaskQueuePC {
     }
   }
 
-  async getNextTask () {
+  getNextTask () {
     return new Promise((resolve) => {
       if (this.taskQueue.length !== 0) {
         return resolve(this.taskQueue.shift())


### PR DESCRIPTION
`async ` keyword not needed as the function already returns a Promise.